### PR TITLE
Fixed paths to work on other OSs

### DIFF
--- a/TES3Merge/Program.cs
+++ b/TES3Merge/Program.cs
@@ -29,7 +29,7 @@ namespace TES3Merge
             {
                 return Directory.GetCurrentDirectory();
             }
-            else if (File.Exists("..\\Morrowind.exe"))
+            else if (File.Exists(Path.Combine("..", "Morrowind.exe")))
             {
                 return Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
             }
@@ -100,7 +100,7 @@ namespace TES3Merge
                 // Load this application's configuration.
                 {
                     var parser = new FileIniDataParser();
-                    string iniPath = $"{AppDomain.CurrentDomain.BaseDirectory}\\TES3Merge.ini";
+                    string iniPath = Path.Combine($"{AppDomain.CurrentDomain.BaseDirectory}", "TES3Merge.ini");
                     Configuration = parser.ReadFile(iniPath);
                 }
 
@@ -234,7 +234,7 @@ namespace TES3Merge
                     try
                     {
                         var parser = new FileIniDataParser();
-                        data = parser.ReadFile($"{morrowindPath}\\Morrowind.ini");
+                        data = parser.ReadFile(Path.Combine($"{morrowindPath}", "Morrowind.ini"));
                     }
                     catch (Exception firstTry)
                     {
@@ -246,7 +246,7 @@ namespace TES3Merge
                             config.SkipInvalidLines = true;
                             config.AllowDuplicateKeys = true;
                             config.AllowDuplicateSections = true;
-                            data = parser.ReadFile($"{morrowindPath}\\Morrowind.ini");
+                            data = parser.ReadFile(Path.Combine($"{morrowindPath}", "Morrowind.ini"));
 
                             // If the first pass fails, be more forgiving, but let the user know their INI has issues.
                             Console.WriteLine("WARNING: Issues were found with your Morrowind.ini file. See TES3Merge.log for details.");
@@ -281,7 +281,7 @@ namespace TES3Merge
                     }
 
                     // Add all ESM files first, then ESP files.
-                    foreach (var path in Directory.GetFiles($"{morrowindPath}\\Data Files", "*.esm", SearchOption.TopDirectoryOnly).OrderBy(p => File.GetLastWriteTime(p).Ticks))
+                    foreach (var path in Directory.GetFiles(Path.Combine($"{morrowindPath}", "Data Files"), "*.esm", SearchOption.TopDirectoryOnly).OrderBy(p => File.GetLastWriteTime(p).Ticks))
                     {
                         var fileName = Path.GetFileName(path);
                         if (activatedMasters.Contains(fileName))
@@ -289,7 +289,7 @@ namespace TES3Merge
                             sortedMasters.Add(fileName);
                         }
                     }
-                    foreach (var path in Directory.GetFiles($"{morrowindPath}\\Data Files", "*.esp", SearchOption.TopDirectoryOnly).OrderBy(p => File.GetLastWriteTime(p).Ticks))
+                    foreach (var path in Directory.GetFiles(Path.Combine($"{morrowindPath}", "Data Files"), "*.esp", SearchOption.TopDirectoryOnly).OrderBy(p => File.GetLastWriteTime(p).Ticks))
                     {
                         var fileName = Path.GetFileName(path);
                         if (activatedMasters.Contains(fileName))
@@ -301,7 +301,7 @@ namespace TES3Merge
                     // Go through and build a record list.
                     foreach (var sortedMaster in sortedMasters)
                     {
-                        string fullGameFilePath = $"{morrowindPath}\\Data Files\\{sortedMaster}";
+                        string fullGameFilePath = Path.Combine($"{morrowindPath}", "Data Files", $"{sortedMaster}");
                         var lastWriteTime = File.GetLastWriteTime(fullGameFilePath);
                         Logger.WriteLine($"Parsing input file: {sortedMaster} @ {lastWriteTime}");
                         TES3 file = TES3.TES3Load(fullGameFilePath, supportedMergeTags);
@@ -446,14 +446,14 @@ namespace TES3Merge
                 {
                     if (usedMasters.Contains(gameFile))
                     {
-                        long size = new FileInfo($"{morrowindPath}\\Data Files\\{gameFile}").Length;
+                        long size = new FileInfo(Path.Combine($"{morrowindPath}", "Data Files", $"{gameFile}")).Length;
                         mergedObjectsHeader.Masters.Add((new TES3Lib.Subrecords.TES3.MAST { Filename = $"{gameFile}\0" }, new TES3Lib.Subrecords.TES3.DATA { MasterDataSize = size }));
                     }
                 }
 
                 // Save out the merged objects file.
                 mergedObjectsHeader.HEDR.NumRecords = mergedObjects.Records.Count - 1;
-                mergedObjects.TES3Save(morrowindPath + "\\Data Files\\Merged Objects.esp");
+                mergedObjects.TES3Save(Path.Combine(morrowindPath, "Data Files", "Merged Objects.esp"));
                 Logger.WriteLine($"Wrote {mergedObjects.Records.Count - 1} merged objects.");
 
                 ShowCompletionPrompt();


### PR DESCRIPTION
I can confirm that TES3Merge can be built on Linux if built using [mono's fork of msbuild](https://github.com/mono/msbuild), however the paths need to be fixed to allow it to interact with the filesystem properly.

I've removed backslashes from paths and added calls to Path.Combine to ensure that the proper separator is used depending on the OS. I left the separators for the registry as they were, given that it's not really meaningful to look in the registry for the installed location of Morrowind on other operating systems, even though mono does actually provide a registry of sorts.