### PR TITLE
Fix/openmw-config

### DIFF
--- a/TES3Merge/Util/Installation.cs
+++ b/TES3Merge/Util/Installation.cs
@@ -430,7 +430,9 @@ public class OpenMWInstallation : Installation
             switch (key)
             {
                 case "data":
-                    DataDirectories.Add(value.Replace('/', '\\'));
+                    var shouldUseBackslash = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+                    var configDir = shouldUseBackslash ? value.Replace('/', '\\') : value;
+                    DataDirectories.Add(configDir);
                     break;
                 case "content":
                     GameFiles.Add(value);

--- a/TES3Merge/Util/Installation.cs
+++ b/TES3Merge/Util/Installation.cs
@@ -419,6 +419,9 @@ public class OpenMWInstallation : Installation
         foreach (var line in File.ReadLines(configPath))
         {
             var tokens = line.Split('=', 2);
+
+            if (tokens.Length < 2) continue;
+
             var key = tokens[0].Trim();
             var value = tokens[1].Trim(new char[] { ' ', '"' });
 

--- a/TES3Merge/Util/Installation.cs
+++ b/TES3Merge/Util/Installation.cs
@@ -384,7 +384,7 @@ public class OpenMWInstallation : Installation
 
     public OpenMWInstallation(string path) : base(path)
     {
-        LoadConfiguration();
+        LoadConfiguration(path);
     }
 
     private static string GetConfigurationLocation()
@@ -408,9 +408,9 @@ public class OpenMWInstallation : Installation
         throw new Exception("Could not determine configuration path.");
     }
 
-    private void LoadConfiguration()
+    private void LoadConfiguration(string configPath)
     {
-        var configPath = GetConfigurationLocation();
+        configPath = Path.Combine(configPath, "openmw.cfg");
         if (!File.Exists(configPath))
         {
             throw new Exception("Configuration file does not exist.");

--- a/TES3Merge/Util/Installation.cs
+++ b/TES3Merge/Util/Installation.cs
@@ -418,6 +418,8 @@ public class OpenMWInstallation : Installation
 
         foreach (var line in File.ReadLines(configPath))
         {
+            if (line.Trim().StartsWith("#")) continue;
+
             var tokens = line.Split('=', 2);
 
             if (tokens.Length < 2) continue;

--- a/TES3Merge/Util/Installation.cs
+++ b/TES3Merge/Util/Installation.cs
@@ -482,7 +482,7 @@ public class OpenMWInstallation : Installation
             .GetFiles(dataFiles, "*", SearchOption.AllDirectories)
             .Where(x => !x.EndsWith(".mohidden"))
             //.Where(x => !x.Contains(Path.DirectorySeparatorChar + ".git" + Path.DirectorySeparatorChar))
-            .Select(x => x[(dataFiles.Length + 1)..]);
+            .Select(x => Path.GetRelativePath(dataFiles, x));
 
         foreach (var file in physicalFiles)
         {


### PR DESCRIPTION
Addresses issues with openmw config parsing discovered by myself and another user in the OpenMW discord that were trying to switch to tes3merge. Notes from #MWSE copied here:

Okay, there were a couple of bugs in the Class implementation for OpenMWInstallation. I'll submit a merge request shortly with my revisions. It seems to handle embedded lua records excellently 😄
I love this thing, holy shit, this codebase is great too. 

QQ: I have two minor grievances with openmw implementation I would like to change, but idk if you would be okay with this:
It makes more sense to me that TES3Merge.exe would be in the same directory as openmw.cfg, not a child directory. In this manner, you keep tes3merge and its config adjacent to openmw.cfg, OR you simply change directory to one which contains openmw.cfg.
If in an openmw installation is detected, OpenMW proper has its own overwrite directory, referred to as data-local in openmw.cfg. This has default locations you can rely on just like openmw.cfg itself (but it's important to note that it's a child directory of the openmw.cfg dir on Windows and NOT unices). So, it'd be nice if perhaps we could explore using that as the install dir, since... I think that's probably what will end up happening if you run tes3merge under MO2 for a vanilla install, just by wildly different means.

Less important, don't actually care:

The class constructor for OpenMWInstallation never actually appears to use this function which returns the hardcoded system path, so.... I'm not really sure what to do about that but it seems like it's worth removing since it's not really how TES3Merge handles detection anyway.