### PR TITLE
CLEANUP: Use a lowercase binary name for more convenient terminal action

### DIFF
--- a/TES3Merge/TES3Merge.csproj
+++ b/TES3Merge/TES3Merge.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <PackageProjectUrl>https://github.com/NullCascade/TES3Merge</PackageProjectUrl>
     <Version>0.11.2</Version>
+    <AssemblyName>tes3merge</AssemblyName>
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 	<ApplicationIcon>tes3merge_icon_by_markel.ico</ApplicationIcon>


### PR DESCRIPTION
Just a minor convenience thing. This could be breaking, I think, maybe? On Windows... Idunno... but I'm expecting to be running this from terminal a lot so a lowercase binary would be cool.