### PR TITLE
FEAT: Try loading tes3merge.ini from CWD first

### DIFF
--- a/TES3Merge/Util/Util.cs
+++ b/TES3Merge/Util/Util.cs
@@ -131,7 +131,11 @@ internal static class Util
     {
         {
             var parser = new FileIniDataParser();
-            var iniPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TES3Merge.ini");
+            var iniPath = Path.Combine(System.IO.Directory.GetCurrentDirectory(), "TES3Merge.ini");
+
+            if (!File.Exists(iniPath))
+                iniPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TES3Merge.ini");
+
             Configuration = parser.ReadFile(iniPath);
         }
 


### PR DESCRIPTION
Like I mentioned in the other openmw.cfg-related MR, it would be neat if tes3merge would try loading configurations from CWD since you can have multiple openmw installations scattered acorss the system.

I'd like also to use this MR to make it attempt loading openmw.cfg from CWD as well, so tes3merge itself can simply sit adjacent to both if it wishes to.

This may perhaps not be the best solution and instead one should be able to specify the path to tes3merge.ini somehow, Idunno.

Part of the problem I wanted to solve is that I'd like to be able to make an AUR package for TES3Merge and install it into a protected system directory, but right now the current setup requires that the configuration be both buried in some random system directory and require superuser permissions to edit. This way, you can just smack it next to openmw.cfg and do whatever.