### PR TITLE
FEAT: Install to the data-local directory if defined

### DIFF
--- a/TES3Merge/Util/Installation.cs
+++ b/TES3Merge/Util/Installation.cs
@@ -597,13 +597,11 @@ public class OpenMWInstallation : Installation
 
     public override string GetDefaultOutputDirectory()
     {
-        // If a data-local directory was defined, always write there to avoid stale files
-        if (!string.IsNullOrEmpty(DataLocalDirectory))
-            return DataDirectories[DataDirectories.Count - 1];
-        // Otherwise just use the first data directory.
-        else if (DataDirectories.Count > 0)
-            return DataDirectories[0];
-        else
+        if (DataDirectories.Count == 0)
             throw new Exception("No data directories defined. No default output directory could be resolved.");
+
+        var outputDirIndex = string.IsNullOrEmpty(DataLocalDirectory) ? 0 : DataDirectories.Count - 1;
+
+        return DataDirectories[outputDirIndex];
     }
 }


### PR DESCRIPTION
NOTE: This depends on #51, but was implemented separatelly in case this aspect may be considered controversial.

If a user's configuration defines a data-local directory, then that directory will always load last.

Some people like to put tool plugins here, including myself. You'll never lose file conflicts when doing this and it's quite convenient.

This behavior is totally opt-in and can *generally* only be used if the user explicitly sets the install directory to the literal openmw installation directory, OR if the user themselves defines a `data-local` key in some other higher-priority configuration file tes3merge is aware of. 

Most people will either not be running tes3merge in this way or, if an explicit install path is set, it'll *probably* be pointing at the default openmw.cfg. I guess maybe there is a vague chance people using OpenMW Player plugin might have data-local directories defined which they both don't know about and tes3merge uses, but if that's the case they're also not likely to have anything in them.

tl;dr this will mostly never happen if you don't want it to.