### PR TITLE
FEAT: Document OutputFile param

### DIFF
--- a/TES3Merge/TES3Merge.ini
+++ b/TES3Merge/TES3Merge.ini
@@ -18,6 +18,10 @@ TextEncodingCode = 1252
 ;  * Have Morrowind's install path in your registry. This only functions on Windows, and will not find OpenMW installations.
 ; InstallPath =
 
+; The folder in which Merged Objects.esp will be saved.
+; If unset, TES3Merge will save Merged Objects.esp to Morrowind's Data Files folder, or a `data-local` folder defined by an openmw.cfg.
+; OutputFile = 
+
 ; Blacklist a file from merging. Set a filename to false to ignore it when merging.
 [FileFilters]
 ; Tamriel_Data.esm = false

--- a/TES3Merge/Util/Installation.cs
+++ b/TES3Merge/Util/Installation.cs
@@ -528,6 +528,21 @@ public class OpenMWInstallation : Installation
                 case "resources":
                     ResourcesDirectory = ParseDataDirectory(configDir, value);
                     break;
+                case "replace":
+                    if (value == "content")
+                        GameFiles.Clear();
+                    else if (value == "data")
+                        DataDirectories.Clear();
+                    else if (value == "config")
+                    {
+                        Archives.Clear();
+                        DataDirectories.Clear();
+                        GameFiles.Clear();
+                        subConfigs.Clear();
+                        ResourcesDirectory = null;
+                        DataLocalDirectory = null;
+                    }
+                    break;
             }
         }
 

--- a/TES3Merge/Util/Installation.cs
+++ b/TES3Merge/Util/Installation.cs
@@ -604,8 +604,20 @@ public class OpenMWInstallation : Installation
         if (DataDirectories.Count == 0)
             throw new Exception("No data directories defined. No default output directory could be resolved.");
 
-        var outputDirIndex = string.IsNullOrEmpty(DataLocalDirectory) ? 0 : DataDirectories.Count - 1;
-
-        return DataDirectories[outputDirIndex];
+        if (!string.IsNullOrEmpty(DataLocalDirectory))
+        {
+            // DataLocalDirectory is always added last
+            return DataDirectories[^1];
+        }
+        else if (!string.IsNullOrEmpty(ResourcesDirectory) && DataDirectories.Count > 1)
+        {
+            // ResourcesDirectory is inserted at index 0, so skip it
+            return DataDirectories[1];
+        }
+        else
+        {
+            // No ResourcesDirectory, so use the first data directory
+            return DataDirectories[0];
+        }
     }
 }

--- a/TES3Merge/Util/Util.cs
+++ b/TES3Merge/Util/Util.cs
@@ -139,6 +139,11 @@ internal static class Util
             if (!File.Exists(iniPath))
                 iniPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "tes3merge", "TES3Merge.ini");
 
+            if (!File.Exists(iniPath))
+            {
+                throw new Exception("TES3Merge was unable to locate a configuration file in any possible location. Aborting.");
+            }
+
             Configuration = parser.ReadFile(iniPath);
         }
 

--- a/TES3Merge/Util/Util.cs
+++ b/TES3Merge/Util/Util.cs
@@ -136,6 +136,9 @@ internal static class Util
             if (!File.Exists(iniPath))
                 iniPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TES3Merge.ini");
 
+            if (!File.Exists(iniPath))
+                iniPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "tes3merge", "TES3Merge.ini");
+
             Configuration = parser.ReadFile(iniPath);
         }
 


### PR DESCRIPTION
Stupid git commands.

Documents the output file param, checks a system directory for tes3merge/TES3Merge.ini, and throw explicitly if no conifguration is found.

Also fixes a regression where weird setups that had a `resources` directory defined, but no `data-local`, would end up resulting in merged objects.esp being placed in `resources/vfs`, where it would be overridden sometimes and also nobody would ever look. Probably this would've happened if someone ran tes3merge against the OpenMW.cfg in Documents/, whilst also having some core shader mod installed (OWSE, Wareya's PBR), but not having an override directory configured.