### PR TITLE
FIX: Document OutputPath parameter correctly

### DIFF
--- a/TES3Merge/TES3Merge.ini
+++ b/TES3Merge/TES3Merge.ini
@@ -20,7 +20,7 @@ TextEncodingCode = 1252
 
 ; The folder in which Merged Objects.esp will be saved.
 ; If unset, TES3Merge will save Merged Objects.esp to Morrowind's Data Files folder, or a `data-local` folder defined by an openmw.cfg.
-; OutputFile = 
+; OutputPath = 
 
 ; Blacklist a file from merging. Set a filename to false to ignore it when merging.
 [FileFilters]


### PR DESCRIPTION
"OutputFile" isn't a parameter.